### PR TITLE
Feat/set default global http timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	xcaddy build --with github.com/buarki/caddy-nats-bridge=./

--- a/app.go
+++ b/app.go
@@ -1,12 +1,12 @@
 package caddy_nats_bridge
 
 import (
-	"github.com/CoverWhale/caddy-nats-bridge/body_jetstream"
-	"github.com/CoverWhale/caddy-nats-bridge/logoutput"
-	"github.com/CoverWhale/caddy-nats-bridge/natsbridge"
-	"github.com/CoverWhale/caddy-nats-bridge/publish"
-	"github.com/CoverWhale/caddy-nats-bridge/request"
-	"github.com/CoverWhale/caddy-nats-bridge/subscribe"
+	"github.com/buarki/caddy-nats-bridge/body_jetstream"
+	"github.com/buarki/caddy-nats-bridge/logoutput"
+	"github.com/buarki/caddy-nats-bridge/natsbridge"
+	"github.com/buarki/caddy-nats-bridge/publish"
+	"github.com/buarki/caddy-nats-bridge/request"
+	"github.com/buarki/caddy-nats-bridge/subscribe"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 )

--- a/body_jetstream/body_jetstream_test.go
+++ b/body_jetstream/body_jetstream_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/CoverWhale/caddy-nats-bridge"
-	"github.com/CoverWhale/caddy-nats-bridge/integrationtest"
+	_ "github.com/buarki/caddy-nats-bridge"
+	"github.com/buarki/caddy-nats-bridge/integrationtest"
 	"github.com/nats-io/nats.go"
 )
 

--- a/body_jetstream/store_body_to_jetstream.go
+++ b/body_jetstream/store_body_to_jetstream.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/CoverWhale/caddy-nats-bridge/common"
-	"github.com/CoverWhale/caddy-nats-bridge/natsbridge"
+	"github.com/buarki/caddy-nats-bridge/common"
+	"github.com/buarki/caddy-nats-bridge/natsbridge"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/nats-io/nats.go"

--- a/examples/timeout-demo/Caddyfile
+++ b/examples/timeout-demo/Caddyfile
@@ -1,0 +1,44 @@
+{
+	nats {
+		url 127.0.0.1:4222
+		defaultTimeout 7s
+	}
+
+	log {
+		level debug
+	}
+}
+
+http://127.0.0.1:8888 {
+	@get method GET
+
+	route /api/fast/* {
+		route @get {
+			nats_request api.fast.{http.request.uri.path.1}
+		}
+	}
+
+	route /api/slow/* {
+		route @get {
+			nats_request api.slow.{http.request.uri.path.1} {
+				timeout 2s
+			}
+		}
+	}
+
+	route /api/very-slow/* {
+		route @get {
+			nats_request api.very-slow.{http.request.uri.path.1}
+		}
+	}
+
+	route /api/custom/* {
+		route @get {
+			nats_request api.custom.{http.request.uri.path.1} {
+				timeout 10s
+			}
+		}
+	}
+
+	respond 405
+}

--- a/examples/timeout-demo/README.md
+++ b/examples/timeout-demo/README.md
@@ -1,0 +1,36 @@
+# Timeout Demo
+
+Simple demo showing HTTP timeout configurations in Caddy-NATS-Bridge.
+
+## Run
+
+1. **Start NATS server:**
+```bash
+nats-server
+```
+
+2. **Start the NATS service:**
+```bash
+go run main.go
+```
+
+3. **Start Caddy:**
+```bash
+xcaddy build --with github.com/buarki/caddy-nats-bridge=./
+./caddy run --config Caddyfile
+```
+
+4. **Test endpoints:**
+```bash
+curl http://127.0.0.1:8888/api/fast/test -i -k -L
+# Expected: 200 in ~1s
+
+curl http://127.0.0.1:8888/api/slow/test -i -k -L
+# Expected: 504 in ~2s (timeout set to 2s, service takes 3s)
+
+curl http://127.0.0.1:8888/api/very-slow/test -i -k -L
+# Expected: 504 in ~7s (default timeout, service takes 8s)
+
+curl http://127.0.0.1:8888/api/custom/test -i -k -L
+# Expected: 200 in ~9s (timeout set to 9s, service takes 9s)
+

--- a/examples/timeout-demo/main.go
+++ b/examples/timeout-demo/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func main() {
+	nc, err := nats.Connect("127.0.0.1:4222")
+	if err != nil {
+		log.Fatal("Failed to connect to NATS:", err)
+	}
+	defer nc.Close()
+
+	fmt.Println("NATS service running on 127.0.0.1:4222")
+	fmt.Println("Subscribing to subjects:")
+	fmt.Println("  api.fast.*      → 1s response")
+	fmt.Println("  api.slow.*      → 3s response")
+	fmt.Println("  api.very-slow.* → 8s response")
+	fmt.Println("  api.custom.*    → 9s response")
+
+	// Subscribe to fast endpoint (1s response)
+	nc.Subscribe("api.fast.*", func(msg *nats.Msg) {
+		time.Sleep(1 * time.Second)
+		msg.Respond([]byte(`{"message": "Fast response in 1s"}`))
+	})
+
+	// Subscribe to slow endpoint (3s response)
+	nc.Subscribe("api.slow.*", func(msg *nats.Msg) {
+		time.Sleep(3 * time.Second)
+		msg.Respond([]byte(`{"message": "Slow response in 3s"}`))
+	})
+
+	// Subscribe to very slow endpoint (8s response - will timeout with 7s default)
+	nc.Subscribe("api.very-slow.*", func(msg *nats.Msg) {
+		time.Sleep(8 * time.Second)
+		msg.Respond([]byte(`{"message": "Very slow response in 8s"}`))
+	})
+
+	// Subscribe to custom endpoint (9s response - will succeed with 9s timeout)
+	nc.Subscribe("api.custom.*", func(msg *nats.Msg) {
+		time.Sleep(9 * time.Second)
+		msg.Respond([]byte(`{"message": "Custom response in 9s"}`))
+	})
+
+	// Keep the service running
+	select {}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CoverWhale/caddy-nats-bridge
+module github.com/buarki/caddy-nats-bridge
 
 go 1.21
 

--- a/integrationtest/caddyfile_adapt_test.go
+++ b/integrationtest/caddyfile_adapt_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/CoverWhale/caddy-nats-bridge"
+	_ "github.com/buarki/caddy-nats-bridge"
 	"github.com/caddyserver/caddy/v2/caddytest"
 )
 

--- a/logoutput/logoutput.go
+++ b/logoutput/logoutput.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/CoverWhale/caddy-nats-bridge/natsbridge"
+	"github.com/buarki/caddy-nats-bridge/natsbridge"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/nats-io/nats.go"

--- a/logoutput/logoutput_test.go
+++ b/logoutput/logoutput_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/CoverWhale/caddy-nats-bridge"
-	"github.com/CoverWhale/caddy-nats-bridge/integrationtest"
+	_ "github.com/buarki/caddy-nats-bridge"
+	"github.com/buarki/caddy-nats-bridge/integrationtest"
 )
 
 // example log message:

--- a/natsbridge/caddyfile.go
+++ b/natsbridge/caddyfile.go
@@ -2,8 +2,9 @@ package natsbridge
 
 import (
 	"encoding/json"
+	"time"
 
-	"github.com/CoverWhale/caddy-nats-bridge/subscribe"
+	"github.com/buarki/caddy-nats-bridge/subscribe"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
@@ -86,6 +87,16 @@ func (app *NatsBridgeApp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 				jsonHandler := caddyconfig.JSONModuleObject(s, "handler", s.CaddyModule().ID.Name(), nil)
 				server.HandlersRaw = append(server.HandlersRaw, jsonHandler)
+			case "defaultTimeout":
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				t, err := time.ParseDuration(d.Val())
+				if err != nil {
+					return d.Err("given default timeout is not a valid duration")
+				}
+
+				server.DefaultTimeout = &t
 			default:
 				return d.Errf("unrecognized subdirective: %s", d.Val())
 			}

--- a/natsbridge/nats_bridge_app_test.go
+++ b/natsbridge/nats_bridge_app_test.go
@@ -1,0 +1,161 @@
+package natsbridge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func TestNatsBridgeApp_DefaultTimeout(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupServer     func(*NatsServer)
+		serverAlias     string
+		expectedTimeout time.Duration
+		expectNil       bool
+	}{
+		{
+			name: "default timeout not set - should use package default",
+			setupServer: func(server *NatsServer) {
+				// don't set DefaultTimeout - should use package default
+			},
+			serverAlias:     "default",
+			expectedTimeout: DefaultTimeout,
+			expectNil:       false,
+		},
+		{
+			name: "default timeout set to custom value",
+			setupServer: func(server *NatsServer) {
+				customTimeout := 5 * time.Second
+				server.DefaultTimeout = &customTimeout
+			},
+			serverAlias:     "default",
+			expectedTimeout: 5 * time.Second,
+			expectNil:       false,
+		},
+		{
+			name: "default timeout set to zero - should keep zero value",
+			setupServer: func(server *NatsServer) {
+				zeroTimeout := time.Duration(0)
+				server.DefaultTimeout = &zeroTimeout
+			},
+			serverAlias:     "default",
+			expectedTimeout: 0,
+			expectNil:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &NatsBridgeApp{
+				Servers: make(map[string]*NatsServer),
+			}
+
+			server := &NatsServer{
+				NatsUrl: "127.0.0.1:4222",
+			}
+			app.Servers[tt.serverAlias] = server
+
+			if tt.setupServer != nil {
+				tt.setupServer(server)
+			}
+
+			ctx := caddy.Context{}
+			err := app.Provision(ctx)
+			if err != nil {
+				t.Fatalf("failed to provision app: %v", err)
+			}
+
+			server, exists := app.Servers[tt.serverAlias]
+			if !exists {
+				if !tt.expectNil {
+					t.Errorf("expected server '%s' to exist, but it doesn't", tt.serverAlias)
+				}
+				return
+			}
+
+			if tt.expectNil {
+				t.Errorf("expected server '%s' to not exist, but it does", tt.serverAlias)
+				return
+			}
+
+			if server.DefaultTimeout == nil {
+				t.Errorf("expected DefaultTimeout to be set, but it's nil")
+				return
+			}
+
+			actualTimeout := *server.DefaultTimeout
+			if actualTimeout != tt.expectedTimeout {
+				t.Errorf("expected timeout %v, got %v", tt.expectedTimeout, actualTimeout)
+			}
+		})
+	}
+}
+
+func TestNatsBridgeApp_DefaultTimeout_MultipleServers(t *testing.T) {
+	app := &NatsBridgeApp{
+		Servers: make(map[string]*NatsServer),
+	}
+
+	server1 := &NatsServer{
+		NatsUrl: "127.0.0.1:4222",
+	}
+	app.Servers["server1"] = server1
+
+	customTimeout := 10 * time.Second
+	server2 := &NatsServer{
+		NatsUrl:        "127.0.0.1:4223",
+		DefaultTimeout: &customTimeout,
+	}
+	app.Servers["server2"] = server2
+
+	ctx := caddy.Context{}
+	err := app.Provision(ctx)
+	if err != nil {
+		t.Fatalf("failed to provision app: %v", err)
+	}
+
+	if server1.DefaultTimeout == nil {
+		t.Errorf("expected server1 DefaultTimeout to be set, but it's nil")
+	} else if *server1.DefaultTimeout != DefaultTimeout {
+		t.Errorf("expected server1 timeout to be %v, got %v", DefaultTimeout, *server1.DefaultTimeout)
+	}
+
+	if server2.DefaultTimeout == nil {
+		t.Errorf("expected server2 DefaultTimeout to be set, but it's nil")
+	} else if *server2.DefaultTimeout != customTimeout {
+		t.Errorf("expected server2 timeout to be %v, got %v", customTimeout, *server2.DefaultTimeout)
+	}
+}
+
+func TestNatsBridgeApp_DefaultTimeout_ProvisionOrder(t *testing.T) {
+	app := &NatsBridgeApp{
+		Servers: make(map[string]*NatsServer),
+	}
+
+	server := &NatsServer{
+		NatsUrl: "127.0.0.1:4222",
+	}
+	app.Servers["default"] = server
+
+	if server.DefaultTimeout != nil {
+		t.Errorf("expected DefaultTimeout to be nil before provisioning, got %v", *server.DefaultTimeout)
+	}
+
+	ctx := caddy.Context{}
+	err := app.Provision(ctx)
+	if err != nil {
+		t.Fatalf("failed to provision app: %v", err)
+	}
+
+	if server.DefaultTimeout == nil {
+		t.Errorf("expected DefaultTimeout to be set after provisioning, but it's nil")
+		return
+	}
+
+	if *server.DefaultTimeout != DefaultTimeout {
+		t.Errorf("expected DefaultTimeout to be %v after provisioning, got %v",
+			DefaultTimeout, *server.DefaultTimeout)
+	}
+}

--- a/publish/publish.go
+++ b/publish/publish.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/CoverWhale/caddy-nats-bridge/common"
-	"github.com/CoverWhale/caddy-nats-bridge/natsbridge"
+	"github.com/buarki/caddy-nats-bridge/common"
+	"github.com/buarki/caddy-nats-bridge/natsbridge"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"

--- a/publish/publish_test.go
+++ b/publish/publish_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/CoverWhale/caddy-nats-bridge"
-	"github.com/CoverWhale/caddy-nats-bridge/integrationtest"
+	_ "github.com/buarki/caddy-nats-bridge"
+	"github.com/buarki/caddy-nats-bridge/integrationtest"
 	"github.com/nats-io/nats.go"
 )
 

--- a/request/caddyfile.go
+++ b/request/caddyfile.go
@@ -1,10 +1,11 @@
 package request
 
 import (
+	"time"
+
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"time"
 )
 
 // ParseRequestHandler parses the nats_request directive. Syntax:
@@ -41,7 +42,7 @@ func (p *Request) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Err("timeout is not a valid duration")
 				}
 
-				p.Timeout = t
+				p.Timeout = &t
 			default:
 				return d.Errf("unrecognized subdirective: %s", d.Val())
 			}

--- a/subscribe/subscribe.go
+++ b/subscribe/subscribe.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	"github.com/CoverWhale/caddy-nats-bridge/common"
+	"github.com/buarki/caddy-nats-bridge/common"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/nats-io/nats.go"

--- a/subscribe/subscribe_test.go
+++ b/subscribe/subscribe_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/CoverWhale/caddy-nats-bridge"
-	"github.com/CoverWhale/caddy-nats-bridge/integrationtest"
+	_ "github.com/buarki/caddy-nats-bridge"
+	"github.com/buarki/caddy-nats-bridge/integrationtest"
 	"github.com/nats-io/nats.go"
 )
 


### PR DESCRIPTION
# Introducing a default http timeout

## Usage

```nginx
{
	nats {
		url 127.0.0.1:4222
		defaultTimeout 5s # <<< default http timeout
	}

	log {
		level debug
	}
}

http://127.0.0.1:8888 {
	route /api/fast/* {
		nats_request api.fast.{http.request.uri.path.1} {
                      timeout 2s # << subject level override
                 }
	}
}
```

## Notes
- in case a default timeout is not provided the default value will be 60s;

## Example of usage
- check [this example](https://github.com/buarki/caddy-nats-bridge/tree/feat/set-default-global-http-timeout/examples/timeout-demo);
- screenshot
![Screenshot 2025-06-21 at 17 01 19](https://github.com/user-attachments/assets/2ba9bddd-fc1c-4aa2-8ca1-5624219965e6)
